### PR TITLE
update README for database

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -25,6 +25,10 @@ The schema and related documentation of data formats can be found in
 psql -d adscraper -U <YOUR_POSTGRES_USERNAME> -f ./adscraper.sql
 ```
 
+<b>Note</b>: You will run into an error if you do not create the database on Postgres App before running the above command. To fix the error, run this slightly modified command (the instructions about ports still apply) and the script will automatically create the database for you:
+
+```psql -U <YOUR_POSTGRES_USERNAME> -f ./adscraper.sql```
+
 ## Setup (for Docker-based crawls)
 To run `crawl-coordinator`, you must set up your Postgres database in Docker,
 so that the Docker-based crawl workers can connect to the database.


### PR DESCRIPTION
Since the adscraper.sql script already has
``` CREATE DATABASE adscaper``` 
command, and since Postgres App for MacOS doesn't provide a clear UI option to make a new database, users can be confused when they encounter an error with the provided command, even though the script seems to create the db.

dropping``` -d adscraper``` removes the error because it does not instruct psql to use adscraper db (which is non-existent until the script is ran once). 

Hence I edited README to cover that scenario to help others.